### PR TITLE
fix(i18n): add missing editor keys and fix broken uk import

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -10,7 +10,7 @@ import nl from './translations/nl.json' with { type: 'json' };
 import pl from './translations/pl.json' with { type: 'json' };
 import ru from './translations/ru.json' with { type: 'json' };
 import sl from './translations/sl.json' with { type: 'json' };
-import ua from './translations/uk.json' with { type: 'json' };
+import uk from './translations/uk.json' with { type: 'json' };
 
 const translations = {
   da,

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -62,8 +62,16 @@
     "period": "Période",
     "show_history_chart": "Afficher l'historique",
     "history_chart_bar_color": "Couleur des barres du graphique d'historique",
+    "invert_history_direction": "Inverser la chronologie du graphique d'historique",
     "show_map": "Afficher la carte",
     "map_theme_mode": "Thème de la carte",
+    "map_marker_style": "Style du marqueur sur la carte",
+    "map_marker_style_options": {
+      "standard": "Standard (icône d'éclair)",
+      "crosshair": "Réticule",
+      "plus": "Plus",
+      "dot": "Point"
+    },
     "period_options": {
       "15m": "15 minutes",
       "30m": "30 minutes",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -62,8 +62,16 @@
     "period": "Periodo",
     "show_history_chart": "Mostra il grafico storico",
     "history_chart_bar_color": "Colore delle barre del grafico storico",
+    "invert_history_direction": "Inverti la cronologia del grafico storico",
     "show_map": "Mostra la mappa",
     "map_theme_mode": "Tema della mappa",
+    "map_marker_style": "Stile del marcatore sulla mappa",
+    "map_marker_style_options": {
+      "standard": "Standard (icona fulmine)",
+      "crosshair": "Mirino",
+      "plus": "Più",
+      "dot": "Punto"
+    },
     "period_options": {
       "15m": "15 minuti",
       "30m": "30 minuti",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -62,8 +62,16 @@
     "period": "Periode",
     "show_history_chart": "Histogram tonen",
     "history_chart_bar_color": "Kolomkleur histogram (optioneel)",
+    "invert_history_direction": "Tijdlijn van historiekgrafiek omkeren",
     "show_map": "Toon kaart",
     "map_theme_mode": "Kaartthema",
+    "map_marker_style": "Kaartmarkeringsstijl",
+    "map_marker_style_options": {
+      "standard": "Standaard (bliksemicoon)",
+      "crosshair": "Kruisdraad",
+      "plus": "Plus",
+      "dot": "Stip"
+    },
     "period_options": {
       "1h": "1 uur",
       "15m": "15 minuten",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -62,8 +62,16 @@
     "period": "Okres",
     "show_history_chart": "Pokaż wykres historii",
     "history_chart_bar_color": "Kolor słupków wykresu historii",
+    "invert_history_direction": "Odwróć oś czasu wykresu historii",
     "show_map": "Pokaż mapę",
     "map_theme_mode": "Motyw mapy",
+    "map_marker_style": "Styl znacznika na mapie",
+    "map_marker_style_options": {
+      "standard": "Standardowy (ikona błyskawicy)",
+      "crosshair": "Celownik",
+      "plus": "Plus",
+      "dot": "Kropka"
+    },
     "period_options": {
       "15m": "15 minut",
       "30m": "30 minut",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -62,8 +62,16 @@
     "period": "Период",
     "show_history_chart": "Показывать график истории",
     "history_chart_bar_color": "Цвет столбцов графика истории",
+    "invert_history_direction": "Инвертировать временную шкалу графика истории",
     "show_map": "Показать карту",
     "map_theme_mode": "Тема карты",
+    "map_marker_style": "Стиль маркера на карте",
+    "map_marker_style_options": {
+      "standard": "Стандартный (значок молнии)",
+      "crosshair": "Перекрестие",
+      "plus": "Плюс",
+      "dot": "Точка"
+    },
     "period_options": {
       "15m": "15 минут",
       "30m": "30 минут",

--- a/src/translations/sl.json
+++ b/src/translations/sl.json
@@ -62,8 +62,16 @@
     "period": "Obdobje",
     "show_history_chart": "Pokaži graf zgodovine",
     "history_chart_bar_color": "Barva stolpcev grafa zgodovine",
+    "invert_history_direction": "Obrni časovnico grafa zgodovine",
     "show_map": "Pokaži zemljevid",
     "map_theme_mode": "Tema zemljevida",
+    "map_marker_style": "Slog oznake na zemljevidu",
+    "map_marker_style_options": {
+      "standard": "Standardno (ikona strele)",
+      "crosshair": "Križec",
+      "plus": "Plus",
+      "dot": "Pika"
+    },
     "period_options": {
       "15m": "15 minut",
       "30m": "30 minut",


### PR DESCRIPTION
## Summary
- `fr`, `it`, `nl`, `pl`, `ru`, and `sl` were missing 6 keys (`editor.invert_history_direction`, `editor.map_marker_style`, `editor.map_marker_style_options.{standard,crosshair,plus,dot}`) that only ever landed in `da`, `de`, `en`, `fi`, and `uk` — those locales were silently falling back to English for the map marker style setting.
- #88's `ua` → `uk` rename left `localize.ts` importing `uk.json` into a binding still named `ua`, while the `translations` object referenced an undeclared `uk` — breaking the TypeScript build on `main`.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` / `npm run check-format` clean
- [x] `npm test` — 47/47 passing
- [x] verified via script that all locale files now have full key parity with `en.json`